### PR TITLE
Add Composer bin directory to $PATH

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,7 @@
 - name: Install Composer
   shell: curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer creates=/usr/local/bin/composer
+
+- name: Add Composer bin directory to $PATH
+  lineinfile: dest=/etc/environment state=present backrefs=yes regexp='PATH=(["]*)((?!.*?{{ item }}).*?)(["]*)$' line="PATH=\1\2:{{ item }}\3"
+  with_items:
+    - "~/.composer/vendor/bin"


### PR DESCRIPTION
Some Composer packages include executable files. The most convenient way to use these packages is to install them globally, in which case the executables (or a symlink to it) are placed in ~/.composer/vendor/bin. 

In most cases these are scripts that are used during development, and by adding this directory to the PATH environment var you don't need to create symlinks in /usr/bin or type the full path to the executable when you want to run it.

E.g. documentation for the Zephir compiler:

> For global installation via composer you can use composer global require. Do not forget add ~/.composer/vendor/bin into your $PATH.

The Composer documentation for vendor binaries is located at https://getcomposer.org/doc/articles/vendor-binaries.md.
